### PR TITLE
Fix typo to allow disabling files backend

### DIFF
--- a/install/assets/functions/30-nextcloud
+++ b/install/assets/functions/30-nextcloud
@@ -142,7 +142,7 @@ configure_application_settings() {
     else
         print_debug "Disabling Hi Performance Files Backend"
         rm -rf /etc/services.available/30-nextcloud
-        sed -i "/include \/etc\/nginx\/sites.available\/files_backend.snippet;/d" /etc/nginx/sites.avaialable/nextcloud.conf
+        sed -i "/include \/etc\/nginx\/sites.available\/files_backend.snippet;/d" /etc/nginx/sites.available/nextcloud.conf
     fi
 
     ### Force Reset Permissions for Security


### PR DESCRIPTION
The files_backend.snippet include statement was not being removed from the sites.available/nextcloud.conf due to an extra 'a'. This typo prevented nginx from starting when disabling files backend option.

```
nextcloud-app            | 2022-12-01.11:00:06 [STARTING] /etc/services.available/10-nginx/run ** [nginx] [5] Starting nginx 1.23.2
nextcloud-app            | + exec nginx
nextcloud-app            | nginx: [emerg] invalid URL prefix in /etc/nginx/sites.available/files_backend.snippet:2
```