### PR TITLE
Update Dockerfile - add clamav-scanner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN source /assets/functions/00-container && \
                         && \
     package install .nextcloud-run-dependencies \
                         c-client \
+			clamav-scanner \
                         coreutils \
                         ffmpeg \
                         findutils \


### PR DESCRIPTION
necessary for the files_antivirus app to avoid error msg 
```
[files_antivirus] Fehler: OCA\Files_Antivirus\BackgroundJob\BackgroundScanner::processFiles, exception: The antivirus executable could not be found at /usr/bin/clamscan
	von ? von -- um 21.05.2024, 17:00:02
```